### PR TITLE
Add exit keys

### DIFF
--- a/pyeez/app.py
+++ b/pyeez/app.py
@@ -27,6 +27,7 @@ class Pyeez(object):
 
     def __init__(self, name):
         self.name = name
+        self.exit_keys = ['q']  # default exit key
         self._stdscr = curses.initscr()
         self._windows = dict()
 
@@ -88,6 +89,8 @@ class Pyeez(object):
                 key = self._stdscr.getkey()
             except KeyboardInterrupt:
                 exit()
+            if key in self.exit_keys:
+                exit()
             Event("key_press", "keyboard", key).dispatch()
 
     def on(self, eventName):
@@ -107,4 +110,15 @@ class Pyeez(object):
         """
         self._stdscr.refresh()
         self._consumeKeyboard()
+
+    def set_exit_keys(self, keys):
+        """
+            Exit the program when one of keys in `keys` is pressed.
+            The default exit keys are: `q` and 'Ctrl + c'.
+
+        :param keys: a list of characters
+        """
+        if keys == None:  # no keys for exiting
+            keys = []
+        self.exit_keys = keys
 

--- a/pyeez/window.py
+++ b/pyeez/window.py
@@ -40,7 +40,9 @@ class Window(object):
         self._conf = {k.upper(): v for k, v in conf.items()}
 
         if 'REFRESH_RATE' in self._conf:
-            threading.Thread(target=self._refreshPeriodically).start()
+            thread = threading.Thread(target=self._refreshPeriodically)
+            thread.daemon = True
+            thread.start()
 
     def _refreshPeriodically(self):
         """


### PR DESCRIPTION
Reference: #1 

I noticed that the programs needed `Ctrl+c` to be pressed twice for exiting. Because the first time, the main thread is interrupted but the other threads (windows) continue running. I solved this by making all of the new threads as daemon before starting them.

Moreover, the programs are exited immediately when the user presses `q`. The programmer can override this. 